### PR TITLE
fix a small typo in documentation

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -115,9 +115,9 @@ class DefaultController extends Controller
     public function getBookAction($id)
     {
         $em = $this->getDoctrine()->getManager();
-        $hostess = $em->getRepository('AcmeBundle:Book')->find($id);
+        $book = $em->getRepository('AcmeBundle:Book')->find($id);
 
-        return new Response($hostess->getName());
+        return new Response($book->getName());
     }
 }
 ```


### PR DESCRIPTION
This corrects a few small glitches in the example of the controller in the documentation page
