### PR TITLE
Clone the original input to preserve useful attributes

### DIFF
--- a/Resources/public/js/autocompleter-jqueryui.js
+++ b/Resources/public/js/autocompleter-jqueryui.js
@@ -9,7 +9,9 @@
             if (options) {
                 $.extend(settings, options);
             }
-            var $this = $(this), $fakeInput = $('<input type="text" name="fake' + $this.attr('name') + '">');
+            var $this = $(this), $fakeInput = $this.clone();
+            $fakeInput.attr('id', 'fake_' + $fakeInput.attr('id'));
+            $fakeInput.attr('name', 'fake_' + $fakeInput.attr('name'));
             $this.hide().after($fakeInput);
             $fakeInput.autocomplete({
                 source: settings.url_list,


### PR DESCRIPTION
This change clones the original input to keep class names and possibly any other attributes.