### PR TITLE
Min input length support

### DIFF
--- a/Resources/public/js/autocompleter-jqueryui.js
+++ b/Resources/public/js/autocompleter-jqueryui.js
@@ -3,7 +3,8 @@
     $.fn.autocompleter = function (options) {
         var settings = {
             url_list: '',
-            url_get:  ''
+            url_get:  '',
+            min_length: 2
         };
         return this.each(function () {
             if (options) {
@@ -15,7 +16,8 @@
                 source: settings.url_list,
                 select: function (event, ui) {
                     $this.val(ui.item.id);
-                }
+                },
+                minLength: settings.min_length
             });
             if ($this.val() !== '') {
                 $.ajax({

--- a/Resources/public/js/autocompleter-select2.js
+++ b/Resources/public/js/autocompleter-select2.js
@@ -4,8 +4,8 @@
         var settings = {
             url_list: '',
             url_get:  '',
-            placeholder: '',
-            minimumInputLength: 2
+            min_length: 2,
+            placeholder: ''
         };
         return this.each(function () {
             if (options) {
@@ -42,7 +42,7 @@
                 escapeMarkup: function (markup) {
                     return markup;
                 },
-                minimumInputLength: settings.minimumInputLength
+                minimumInputLength: settings.min_length
             });
             if ($this.val() !== '') {
                 $.ajax({

--- a/Resources/public/js/autocompleter-select2.js
+++ b/Resources/public/js/autocompleter-select2.js
@@ -4,7 +4,8 @@
         var settings = {
             url_list: '',
             url_get:  '',
-            placeholder: ''
+            placeholder: '',
+            minimumInputLength: 2
         };
         return this.each(function () {
             if (options) {
@@ -41,7 +42,7 @@
                 escapeMarkup: function (markup) {
                     return markup;
                 },
-                minimumInputLength: 2
+                minimumInputLength: settings.minimumInputLength
             });
             if ($this.val() !== '') {
                 $.ajax({


### PR DESCRIPTION
Set the default value for ```min_length``` at ```autocompleter-jqueryui.js``` to ```2``` to be consistent with the select2 one.

Also, this fixes #14.