### PR TITLE
Add support for a callback function on select (jQueryUI version)

### DIFF
--- a/Resources/public/js/autocompleter-jqueryui.js
+++ b/Resources/public/js/autocompleter-jqueryui.js
@@ -1,6 +1,6 @@
 (function ($) {
     'use strict';
-    $.fn.autocompleter = function (options) {
+    $.fn.autocompleter = function (options, onSelectCallback) {
         var settings = {
             url_list: '',
             url_get:  '',
@@ -18,6 +18,9 @@
                 source: settings.url_list,
                 select: function (event, ui) {
                     $this.val(ui.item.id);
+                    if (onSelectCallback) {
+                        onSelectCallback($this);
+                    }
                 },
                 minLength: settings.min_length
             });


### PR DESCRIPTION
I don't think there's much need for something like this on the Select2 version because in there I guess we can make use of the `on('change')` event binded to the fake input (have not tested that though).

However in the jQueryUI version I was having some troubles executing a custom function when I selected a value for the input, that's why I've made this change.

Thanking @rntdrts regarding this.