### PR TITLE
Set the "required" option to false by default

### DIFF
--- a/src/Form/Type/AutocompleteFilterType.php
+++ b/src/Form/Type/AutocompleteFilterType.php
@@ -2,8 +2,19 @@
 
 namespace PUGX\AutocompleterBundle\Form\Type;
 
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
 class AutocompleteFilterType extends AutocompleteType
 {
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefaults([
+            'required' => false,
+        ]);
+    }
+
     public function getBlockPrefix(): string
     {
         return 'filter_autocomplete';


### PR DESCRIPTION
LexikFormFilterBundle sets this option to false for all the types it defines. Besides, it generally doesn't make sense to make a filter input required.