### PR TITLE
Update autocomplete-jqueryui.js to give access to event and ui

### DIFF
--- a/Resources/public/js/autocompleter-jqueryui.js
+++ b/Resources/public/js/autocompleter-jqueryui.js
@@ -22,7 +22,7 @@
                     $this.val(ui.item.value);
                     $(this).val(ui.item.label);
                     if (settings.on_select_callback) {
-                        settings.on_select_callback($this);
+                        settings.on_select_callback($this, event, ui);
                     }
                 },
                 minLength: settings.min_length


### PR DESCRIPTION
Give access to 'event' and 'ui' in the 'on_select_callback'. Can then send extra information through the json object to act on after the item is selected.